### PR TITLE
Option  --install-prefix

### DIFF
--- a/.github/workflows/makezip.yaml
+++ b/.github/workflows/makezip.yaml
@@ -15,7 +15,7 @@ jobs:
         [[ $(uname) == Linux ]] && sudo apt-get install -y openmpi-bin libopenmpi-dev
         ./install.sh
         source miniforge3/bin/activate dgfem
-        ./makezip.sh ./mirgecom/requirements.txt ./
+        ./makezip.sh ./mirgecom/requirements.txt
     - name: Test modules.zip
       run: |
         source miniforge3/bin/activate dgfem

--- a/.github/workflows/makezip.yaml
+++ b/.github/workflows/makezip.yaml
@@ -15,7 +15,7 @@ jobs:
         [[ $(uname) == Linux ]] && sudo apt-get install -y openmpi-bin libopenmpi-dev
         ./install.sh
         source $HOME/miniforge3/bin/activate dgfem
-        ./makezip.sh
+        ./makezip.sh ./mirgecom/requirements.txt ./
     - name: Test modules.zip
       run: |
         source $HOME/miniforge3/bin/activate dgfem

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Version info
       run: |
         source $HOME/miniforge3/bin/activate dgfem
-        ./version.sh ./mirgecom/requirements
+        ./version.sh ./mirgecom/requirements.txt
     - name: Run wave-eager
       run: |
         source $HOME/miniforge3/bin/activate dgfem

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Version info
       run: |
         source $HOME/miniforge3/bin/activate dgfem
-        ./version.sh
+        ./version.sh ./mirgecom/requirements
     - name: Run wave-eager
       run: |
         source $HOME/miniforge3/bin/activate dgfem

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mcbranch=$1
+mcprefix=$2
+# default it to branch=master, install=PWD
+if [ -z "$mcbranch" ]; then mcbranch="master"; fi
+if [ -z "$mcprefix" ]; then mcprefix=`pwd`; fi
+# create or populate mirgecom from repo
+mcsrc=$mcprefix/mirgecom
+if [ -f $mcsrc/setup.py ]
+then   # mirgecom src already populated, checkout the right branch, pull it
+    cd ${mcsrc}&&git checkout ${mcbranch}&&git pull
+else   # clone specific branch to mirgecom src
+    cd $mcprefix && git clone -b ${mcbranch} https://github.com/illinois-ceesd/mirgecom
+fi
+

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -9,7 +9,7 @@ mcprefix=$2
 mcsrc=$mcprefix/mirgecom
 if [[ -f "$mcsrc/setup.py" ]]
 then   # mirgecom src already populated, checkout the right branch, pull it
-    cd ${mcsrc}&&git checkout ${mcbranch}&&git pull
+    cd ${mcsrc} && git checkout ${mcbranch} && git pull
 else   # clone specific branch to mirgecom src
     cd $mcprefix && git clone -b ${mcbranch} https://github.com/illinois-ceesd/mirgecom
 fi

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -o nounset -o errexit
 mcbranch=$1
 mcprefix=$2
 # default it to branch=master, install=PWD
@@ -13,4 +13,3 @@ then   # mirgecom src already populated, checkout the right branch, pull it
 else   # clone specific branch to mirgecom src
     cd $mcprefix && git clone -b ${mcbranch} https://github.com/illinois-ceesd/mirgecom
 fi
-

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -8,13 +8,11 @@
 #
 
 set -o nounset -o errexit
+
+# default it to branch=master, install=PWD
 origin=$(pwd)
 mcbranch="${1-master}"
 mcprefix="${2-$origin}"
-
-# default it to branch=master, install=PWD
-# [[ -z "$mcbranch" ]] && mcbranch="master"
-# [[ -z "$mcprefix" ]] && mcprefix=$(pwd)
 
 # create or populate mirgecom from repo
 mcsrc=$mcprefix/mirgecom

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -8,12 +8,14 @@
 #
 
 set -o nounset -o errexit
+origin=$(pwd)
+mcbranch="${1-master}"
+mcprefix="${2-$origin}"
 
-mcbranch=$1
-mcprefix=$2
 # default it to branch=master, install=PWD
-[[ -z "$mcbranch" ]] && mcbranch="master"
-[[ -z "$mcprefix" ]] && mcprefix=$(pwd)
+# [[ -z "$mcbranch" ]] && mcbranch="master"
+# [[ -z "$mcprefix" ]] && mcprefix=$(pwd)
+
 # create or populate mirgecom from repo
 mcsrc=$mcprefix/mirgecom
 if [[ -f "$mcsrc/setup.py" ]]

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -7,7 +7,7 @@ mcprefix=$2
 [[ -z "$mcprefix" ]] && mcprefix=$(pwd)
 # create or populate mirgecom from repo
 mcsrc=$mcprefix/mirgecom
-if [ -f $mcsrc/setup.py ]
+if [[ -f "$mcsrc/setup.py" ]]
 then   # mirgecom src already populated, checkout the right branch, pull it
     cd ${mcsrc}&&git checkout ${mcbranch}&&git pull
 else   # clone specific branch to mirgecom src

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -3,7 +3,7 @@
 # This script simply grabs mirgecom from the CEESD repo (if necessary)
 # puts it in <install_directory>/mirgecom, and makes the specified
 # <branchname> current.
-# 
+#
 # Usage: fetch-mirgecom.sh <branchname> <install_directory>
 #
 
@@ -15,10 +15,16 @@ mcbranch="${1-master}"
 mcprefix="${2-$origin}"
 
 # create or populate mirgecom from repo
-mcsrc=$mcprefix/mirgecom
+mcsrc="$mcprefix/mirgecom"
+
 if [[ -f "$mcsrc/setup.py" ]]
-then   # mirgecom src already populated, checkout the right branch, pull it
-    cd ${mcsrc} && git checkout ${mcbranch} && git pull
-else   # clone specific branch to mirgecom src
-    cd $mcprefix && git clone -b ${mcbranch} https://github.com/illinois-ceesd/mirgecom
+then
+    # mirgecom src already populated, checkout the right branch, pull it
+    cd "$mcsrc"
+    git checkout "$mcbranch"
+    git pull
+else
+    # clone specific branch to mirgecom src
+    cd "$mcprefix"
+    git clone --branch "$mcbranch" https://github.com/illinois-ceesd/mirgecom
 fi

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -3,8 +3,8 @@ set -o nounset -o errexit
 mcbranch=$1
 mcprefix=$2
 # default it to branch=master, install=PWD
-if [ -z "$mcbranch" ]; then mcbranch="master"; fi
-if [ -z "$mcprefix" ]; then mcprefix=`pwd`; fi
+[[ -z "$mcbranch" ]] && mcbranch="master"
+[[ -z "$mcprefix" ]] && mcprefix=$(pwd)
 # create or populate mirgecom from repo
 mcsrc=$mcprefix/mirgecom
 if [ -f $mcsrc/setup.py ]

--- a/fetch-mirgecom.sh
+++ b/fetch-mirgecom.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+#
+# This script simply grabs mirgecom from the CEESD repo (if necessary)
+# puts it in <install_directory>/mirgecom, and makes the specified
+# <branchname> current.
+# 
+# Usage: fetch-mirgecom.sh <branchname> <install_directory>
+#
+
 set -o nounset -o errexit
+
 mcbranch=$1
 mcprefix=$2
 # default it to branch=master, install=PWD

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -15,10 +15,7 @@ origin=$(pwd)
 requirements_file="${1-mirgecom/requirements.txt}"
 install_location="${2-$origin}"
 
-if [ ! -d "$install_location" ]
-then
-    mkdir -p $install_location
-fi
+mkdir -p $install_location
 source ./parse_requirements.sh
 
 parse_requirements $requirements_file
@@ -67,4 +64,3 @@ done
 unset module_names
 unset module_urls
 unset module_branches
-

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+#
+# This script reads the dependency package information from
+# the caller-supplied <requirements_file> (presumably <package>/requirements.txt)
+# and installs them by an appropriate method (i.e. as a development package)
+# to the caller-supplied <install_location>, which defaults to the PWD.
+#
+# Usage: install-pip-dependencies <requirements_file> <install_location>
+#
+
 set -o nounset -o errexit
 
 requirements_file=$1

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -15,10 +15,6 @@ origin=$(pwd)
 requirements_file="${1-mirgecom/requirements.txt}"
 install_location="${2-$origin}"
 
-#if [[ -z "$install_location" ]]
-#then
-#    install_location=$(pwd)
-#fi
 if [ ! -d "$install_location" ]
 then
     mkdir -p $install_location

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -14,9 +14,9 @@ set -o nounset -o errexit
 requirements_file=$1
 install_location=$2
 
-if [ -z "$install_location" ]
+if [[ -z "$install_location" ]]
 then
-    install_location=`pwd`
+    install_location=$(pwd)
 fi
 if [ ! -d "$install_location" ]
 then

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -11,13 +11,14 @@
 
 set -o nounset -o errexit
 
-requirements_file=$1
-install_location=$2
+origin=$(pwd)
+requirements_file="${1-mirgecom/requirements.txt}"
+install_location="${2-$origin}"
 
-if [[ -z "$install_location" ]]
-then
-    install_location=$(pwd)
-fi
+#if [[ -z "$install_location" ]]
+#then
+#    install_location=$(pwd)
+#fi
 if [ ! -d "$install_location" ]
 then
     mkdir -p $install_location

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -62,7 +62,7 @@ for i in "${!module_names[@]}"; do
         install_mode="develop"
         if [[ $name == "f2py" ]]; then
             # f2py/fparser doesn't use setuptools, so 'develop' isn't a thing
-            install_mode = "install"
+            install_mode="install"
         fi
         ./install-src-package.sh $install_location/$name $install_mode
     fi

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -53,7 +53,7 @@ for i in "${!module_names[@]}"; do
             git checkout "$branch"
         else
             cd "$install_location/$name"
-            git checkout "$branch"
+            [[ -n $branch ]] && git checkout "$branch"
             git pull
         fi
 

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -50,7 +50,7 @@ for i in "${!module_names[@]}"; do
         then
             cd "$install_location"
             git clone --recursive "$url" "$name"
-            git checkout "$branch"
+            [[ -n $branch ]] && git checkout "$branch"
         else
             cd "$install_location/$name"
             [[ -n $branch ]] && git checkout "$branch"

--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -2,18 +2,30 @@
 
 set -o nounset -o errexit
 
+requirements_file=$1
+install_location=$2
 
+if [ -z "$install_location" ]
+then
+    install_location=`pwd`
+fi
+if [ ! -d "$install_location" ]
+then
+    mkdir -p $install_location
+fi
 source ./parse_requirements.sh
 
-parse_requirements
+parse_requirements $requirements_file
 
 echo "==== Installing pip packages"
 
 # Required for pyopencl
 python -m pip install pybind11 mako
-MY_CONDA_PATH="$(conda info --envs | grep dgfem | awk '{print $3}')"
 
+# Get the *active* env path
+MY_CONDA_PATH="$(conda info --envs | grep '*' | awk '{print $NF}')"
 
+origin=`pwd`
 for i in "${!module_names[@]}"; do
     name=${module_names[$i]}
     branch=${module_branches[$i]}
@@ -24,14 +36,19 @@ for i in "${!module_names[@]}"; do
         pip install --upgrade $name
     else
         echo "=== Installing git module $name $url ${branch/--branch /}"
-        [[ ! -d $name ]] && git clone --recursive $branch $url
-
+        if [ ! -d "$install_location/$name" ]
+        then
+            cd $install_location && git clone --recursive $branch $url $name 
+        else
+            cd $install_location/$name && git checkout $branch && git pull
+        fi
         [[ $name == "pyopencl" || $name == "islpy" ]] && continue
-
+        cd $origin
         # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
-        (cd $name && python setup.py develop)
+        ./install-src-package.sh $install_location/$name
     fi
 done
+unset module_names
+unset module_urls
+unset module_branches
 
-# See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
-(cd mirgecom && python setup.py develop)

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 packagepath=$1
-if [ -z "$packagepath" ]
+if [[ -z "$packagepath" ]]
 then
     printf "Error: No package path given.\n"
 fi
 # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
 (cd $packagepath && python setup.py develop)
-

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+packagepath=$1
+if [ -z "$packagepath" ]
+then
+    printf "Error: No package path given.\n"
+fi
+# See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
+(cd $packagepath && python setup.py develop)
+

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -8,16 +8,21 @@
 #
 set -o nounset -o errexit
 
+if [ $# -eq 0 ]
+then
+    echo "install-src-package.sh:Error: No package path given."
+    exit 1
+fi
 packagepath=$1
-installmode=$2
+installmode="${2-develop}"
 
-if [[ -z "$packagepath" ]]
-then
-    echo "Error: No package path given."
-fi
-if [[ -z "$installmode" ]]
-then
-    installmode="develop"
-fi
+#if [[ -z "$packagepath" ]]
+#then
+#    echo "Error: No package path given."
+#fi
+#if [[ -z "$installmode" ]]
+#then
+#    installmode="develop"
+#fi
 # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
 (cd $packagepath && python setup.py $installmode)

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o nounset -o errexit
+
 packagepath=$1
 if [[ -z "$packagepath" ]]
 then

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -16,13 +16,5 @@ fi
 packagepath=$1
 installmode="${2-develop}"
 
-#if [[ -z "$packagepath" ]]
-#then
-#    echo "Error: No package path given."
-#fi
-#if [[ -z "$installmode" ]]
-#then
-#    installmode="develop"
-#fi
 # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
 (cd $packagepath && python setup.py $installmode)

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -3,7 +3,7 @@
 packagepath=$1
 if [[ -z "$packagepath" ]]
 then
-    printf "Error: No package path given.\n"
+    echo "Error: No package path given."
 fi
 # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
 (cd $packagepath && python setup.py develop)

--- a/install-src-package.sh
+++ b/install-src-package.sh
@@ -8,7 +8,7 @@
 #
 set -o nounset -o errexit
 
-if [ $# -eq 0 ]
+if [[ $# -eq 0 ]]
 then
     echo "install-src-package.sh:Error: No package path given."
     exit 1
@@ -17,4 +17,4 @@ packagepath=$1
 installmode="${2-develop}"
 
 # See https://github.com/illinois-ceesd/mirgecom/pull/43 for why this is not 'pip install -e .'
-(cd $packagepath && python setup.py $installmode)
+(cd "$packagepath" && python setup.py "$installmode")

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,6 @@ usage()
   echo "  --help                Print this help text."
 }
 
-# Default conda location
-# conda_prefix=$HOME/miniforge3
 mcbranch="master"
 mcprefix=$(pwd)
 # {{{ Default conda location

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ usage()
   echo "Usage: $0 [--install-prefix=DIR] [--conda-prefix=DIR] [--branch=NAME]" 
   echo "                   [--modules] [--help]"
   echo "  --install-prefix=DIR  Install mirgecom in [DIR], (default=PWD)."
-  echo "  --conda-prefix=DIR    Install conda in [DIR], (default=~/Miniconda3)"
+  echo "  --conda-prefix=DIR    Install conda in [DIR], (default=~/miniforge3)"
   echo "  --modules             Create modules.zip and add to Python path."
   echo "  --branch=NAME         Install specific branch of mirgecom (default=master)."
   echo "  --help                Print this help text."

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,25 @@ set -o errexit
 # Conda does not like 'set -o nounset'
 
 echo "#####################################################"
-echo "# This script installs the dependencies for emirge. #"
+echo "# This script installs mirgecom, and dependencies.  #"
 echo "#####################################################"
 echo
 
 usage()
 {
-  echo "Usage: $0 [--prefix=DIR] [--branch=NAME] [--modules] [--help]"
-  echo "  --prefix=DIR      Install conda in non-default prefix."
-  echo "  --modules         Create modules.zip and add to Python path."
-  echo "  --branch=NAME     Install specific branch of mirgecom (default=master)."
-  echo "  --help            Print this help text."
+  echo "Usage: $0 [--install-prefix=DIR] [--conda-prefix=DIR] [--branch=NAME]" 
+  echo "                   [--modules] [--help]"
+  echo "  --install-prefix=DIR  Install mirgecom in [DIR], (default=PWD)."
+  echo "  --conda-prefix=DIR    Install conda in [DIR], (default=~/Miniconda3)"
+  echo "  --modules             Create modules.zip and add to Python path."
+  echo "  --branch=NAME         Install specific branch of mirgecom (default=master)."
+  echo "  --help                Print this help text."
 }
 
 # Default conda location
 conda_prefix=$HOME/miniforge3
-mirgecom_branch="master"
+mcbranch="master"
+mcprefix=`pwd`
 
 # Build modules.zip? (via makezip.sh)
 opt_modules=0
@@ -28,13 +31,17 @@ while [[ $# -gt 0 ]]; do
   arg=$1
   shift
   case $arg in
-    --prefix=*)
+    --install-prefix=*)
+        # Install mirgecom in non-default prefix
+        mcprefix=${arg#*=}
+        ;;
+    --conda-prefix=*)
         # Install conda in non-default prefix
         conda_prefix=${arg#*=}
         ;;
     --branch=*)
         # Install specified branch of mirgecom
-        mirgecom_branch=${arg#*=}
+        mcbranch=${arg#*=}
         ;;
     --modules)
         # Create modules.zip
@@ -53,7 +60,8 @@ done
 
 # Conda does not like ~
 conda_prefix=$(echo $conda_prefix | sed s,~,$HOME,)
-export EMIRGE_MIRGECOM_BRANCH=$mirgecom_branch
+mcprefix=$(echo $mcprefix | sed s,~,$HOME,)
+export EMIRGE_MIRGECOM_BRANCH=$mcbranch
 export MY_CONDA_DIR=$conda_prefix
 
 ./install-conda.sh
@@ -70,8 +78,16 @@ conda create --name dgfem --yes
 
 source $MY_CONDA_DIR/bin/activate dgfem
 
+if [ ! -d $mcprefix ]
+then
+    mkdir -p $mcprefix
+fi
+mcsrc=$mcprefix/mirgecom
+
+./fetch-mirgecom.sh $mcbranch $mcprefix
 ./install-conda-dependencies.sh
-./install-pip-dependencies.sh
+./install-pip-dependencies.sh $mcsrc/requirements.txt $mcprefix
+./install-src-package.sh $mcsrc
 
 unset EMIRGE_MIRGECOM_BRANCH
 
@@ -79,8 +95,12 @@ unset EMIRGE_MIRGECOM_BRANCH
 
 echo
 echo "==================================================================="
-echo "Emirge is now installed. Please run the following commands"
-echo "to test the installation (assuming your shell is bash):"
+echo "Mirgecom is now installed in $mcsrc." 
+echo "Before using this installation, one should load the appropriate"
+echo "conda environment (assuming bash shell):"
 echo " $ source $conda_prefix/bin/activate dgfem"
-echo " $ python mirgecom/examples/wave-eager.py"
+echo "Then, to test the installation:"
+echo " $ cd $mcsrc/test && pytest *.py"
+echo "To run the examples:"
+echo " $ cd $mcsrc/examples && ./run_examples.sh ./"
 echo "==================================================================="

--- a/install.sh
+++ b/install.sh
@@ -78,10 +78,7 @@ conda create --name dgfem --yes
 
 source $MY_CONDA_DIR/bin/activate dgfem
 
-if [ ! -d $mcprefix ]
-then
-    mkdir -p $mcprefix
-fi
+mkdir -p $mcprefix
 mcsrc=$mcprefix/mirgecom
 
 ./fetch-mirgecom.sh $mcbranch $mcprefix

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ usage()
 # Default conda location
 conda_prefix=$HOME/miniforge3
 mcbranch="master"
-mcprefix=`pwd`
+mcprefix=$(pwd)
 
 # Build modules.zip? (via makezip.sh)
 opt_modules=0

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ echo
 
 usage()
 {
-  echo "Usage: $0 [--install-prefix=DIR] [--conda-prefix=DIR] [--branch=NAME]" 
+  echo "Usage: $0 [--install-prefix=DIR] [--conda-prefix=DIR] [--branch=NAME]"
   echo "                   [--modules] [--help]"
   echo "  --install-prefix=DIR  Install mirgecom in [DIR], (default=PWD)."
   echo "  --conda-prefix=DIR    Install conda in [DIR], (default=~/miniforge3)"
@@ -87,13 +87,13 @@ conda create --name dgfem --yes
 #shellcheck disable=SC1090
 source "$MY_CONDA_DIR"/bin/activate dgfem
 
-mkdir -p $mcprefix
+mkdir -p "$mcprefix"
 mcsrc=$mcprefix/mirgecom
 
-./fetch-mirgecom.sh $mcbranch $mcprefix
+./fetch-mirgecom.sh "$mcbranch" "$mcprefix"
 ./install-conda-dependencies.sh
-./install-pip-dependencies.sh $mcsrc/requirements.txt $mcprefix
-./install-src-package.sh $mcsrc "develop"
+./install-pip-dependencies.sh "$mcsrc/requirements.txt" "$mcprefix"
+./install-src-package.sh "$mcsrc" "develop"
 
 unset EMIRGE_MIRGECOM_BRANCH
 
@@ -101,7 +101,7 @@ unset EMIRGE_MIRGECOM_BRANCH
 
 echo
 echo "==================================================================="
-echo "Mirgecom is now installed in $mcsrc." 
+echo "Mirgecom is now installed in $mcsrc."
 echo "Before using this installation, one should load the appropriate"
 echo "conda environment (assuming bash shell):"
 echo " $ source $conda_prefix/bin/activate dgfem"

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ mcsrc=$mcprefix/mirgecom
 ./fetch-mirgecom.sh $mcbranch $mcprefix
 ./install-conda-dependencies.sh
 ./install-pip-dependencies.sh $mcsrc/requirements.txt $mcprefix
-./install-src-package.sh $mcsrc
+./install-src-package.sh $mcsrc "develop"
 
 unset EMIRGE_MIRGECOM_BRANCH
 

--- a/makezip.sh
+++ b/makezip.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset
+origin=$(pwd)
+
+requirements_file=""
+install_loc=""
 
 if [ ! -z "$1" ]
 then
     requirements_file=$1
+    if [ ! -z "$2" ]
+    then
+        install_loc=$2
+    fi
 fi
-if [ ! -z "$2" ]
-then
-    install_loc=$2
-fi
-origin=$(pwd)
-
 if [ -z "$requirements_file" ]
 then
     printf "makezip.sh::Error: Requirements file must be specified.\n"

--- a/makezip.sh
+++ b/makezip.sh
@@ -1,35 +1,16 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset
-origin=$(pwd)
 
+origin=$(pwd)
 requirements_file="${1-$origin}"
 install_loc="${2-$origin}"
-
-#if [ ! -z "$1" ]
-#then
-#    requirements_file=$1
-#    if [ ! -z "$2" ]
-#    then
-#        install_loc=$2
-#    fi
-#fi
-#if [ -z "$requirements_file" ]
-#then
-#    printf "makezip.sh::Error: Requirements file must be specified.\n"
-#    exit 1
-#fi
 
 if [ ! -f "$requirements_file" ]
 then
     printf "makezip.sh::Error: Requirements file ($requirements_file) does not exist.\n"
     exit 1    
 fi
-#if [ -z "$install_loc" ]
-#then
-#    install_loc=$(pwd)
-#    printf "makezip.sh::Warning: No install location given, defaulting to ($install_loc).\n"
-#fi
 
 source ./parse_requirements.sh
 parse_requirements $requirements_file

--- a/makezip.sh
+++ b/makezip.sh
@@ -8,12 +8,12 @@ install_loc="${2-$origin}"
 
 if [ ! -f "$requirements_file" ]
 then
-    printf "makezip.sh::Error: Requirements file ($requirements_file) does not exist.\n"
-    exit 1    
+    echo "makezip.sh::Error: Requirements file ($requirements_file) does not exist."
+    exit 1
 fi
 
 source ./parse_requirements.sh
-parse_requirements $requirements_file
+parse_requirements "$requirements_file"
 
 zipfile=$install_loc/modules.zip
 
@@ -36,7 +36,7 @@ for i in "${!module_names[@]}"; do
     cd "$install_loc/$name"
     echo "=== Zipping $name"
     zip -r "$zipfile" "$name/"
-    cd $origin
+    cd "$origin"
 done
 
 MY_PYTHON=$(command -v python3)
@@ -47,8 +47,8 @@ echo
 
 sitepath="$($MY_PYTHON -c 'import site; print(site.getsitepackages()[0])')"
 sitefile="$sitepath/emirge.pth"
-printf "Found site path: ${sitepath}\n"
-printf "Attempting to make site file: ${sitefile}\n"
+echo "Found site path: $sitepath"
+echo "Attempting to make site file: $sitefile"
 
 echo "$zipfile" > "$sitefile"
 

--- a/makezip.sh
+++ b/makezip.sh
@@ -2,9 +2,15 @@
 
 set -o errexit -o nounset
 
-requirements_file=$1
-install_loc=$2
-origin=`pwd`
+if [ ! -z "$1" ]
+then
+    requirements_file=$1
+fi
+if [ ! -z "$2" ]
+then
+    install_loc=$2
+fi
+origin=$(cwd)
 
 if [ -z "$requirements_file" ]
 then
@@ -20,7 +26,7 @@ fi
 
 if [ -z "$install_loc" ]
 then
-    install_loc=`pwd`
+    install_loc=$(cwd)
     printf "makezip.sh::Warning: No install location given, defaulting to ($install_loc).\n"
 fi
 
@@ -57,7 +63,10 @@ echo "=== Preparing path file of '$MY_PYTHON'"
 echo "=== for importing modules from '$zipfile'"
 echo
 
-sitefile="$($MY_PYTHON -c 'import site; print(site.getsitepackages()[0])')/emirge.pth"
+sitepath="$($MY_PYTHON -c 'import site; print(site.getsitepackages()[0])')"
+sitefile="$sitepath/emirge.pth"
+printf "Found site path: ${sitepath}\n"
+printf "Attempting to make site file: ${sitefile}\n"
 
 echo "$zipfile" > "$sitefile"
 

--- a/makezip.sh
+++ b/makezip.sh
@@ -3,34 +3,33 @@
 set -o errexit -o nounset
 origin=$(pwd)
 
-requirements_file=""
-install_loc=""
+requirements_file="${1-$origin}"
+install_loc="${2-$origin}"
 
-if [ ! -z "$1" ]
-then
-    requirements_file=$1
-    if [ ! -z "$2" ]
-    then
-        install_loc=$2
-    fi
-fi
-if [ -z "$requirements_file" ]
-then
-    printf "makezip.sh::Error: Requirements file must be specified.\n"
-    exit 1
-fi
+#if [ ! -z "$1" ]
+#then
+#    requirements_file=$1
+#    if [ ! -z "$2" ]
+#    then
+#        install_loc=$2
+#    fi
+#fi
+#if [ -z "$requirements_file" ]
+#then
+#    printf "makezip.sh::Error: Requirements file must be specified.\n"
+#    exit 1
+#fi
 
 if [ ! -f "$requirements_file" ]
 then
     printf "makezip.sh::Error: Requirements file ($requirements_file) does not exist.\n"
     exit 1    
 fi
-
-if [ -z "$install_loc" ]
-then
-    install_loc=$(pwd)
-    printf "makezip.sh::Warning: No install location given, defaulting to ($install_loc).\n"
-fi
+#if [ -z "$install_loc" ]
+#then
+#    install_loc=$(pwd)
+#    printf "makezip.sh::Warning: No install location given, defaulting to ($install_loc).\n"
+#fi
 
 source ./parse_requirements.sh
 parse_requirements $requirements_file

--- a/makezip.sh
+++ b/makezip.sh
@@ -10,7 +10,7 @@ if [ ! -z "$2" ]
 then
     install_loc=$2
 fi
-origin=$(cwd)
+origin=$(pwd)
 
 if [ -z "$requirements_file" ]
 then
@@ -26,7 +26,7 @@ fi
 
 if [ -z "$install_loc" ]
 then
-    install_loc=$(cwd)
+    install_loc=$(pwd)
     printf "makezip.sh::Warning: No install location given, defaulting to ($install_loc).\n"
 fi
 

--- a/makezip.sh
+++ b/makezip.sh
@@ -59,7 +59,7 @@ echo
 
 sitefile="$($MY_PYTHON -c 'import site; print(site.getsitepackages()[0])')/emirge.pth"
 
-echo "$zipfile" > "$install_loc/$sitefile"
+echo "$zipfile" > "$sitefile"
 
 echo "=== Done. Make sure to uninstall other copies of the emirge modules:"
 echo "=== $MY_PYTHON -m pip uninstall $MY_MODULES"

--- a/parse_requirements.sh
+++ b/parse_requirements.sh
@@ -1,13 +1,21 @@
 
-EMIRGE_MIRGECOM_BRANCH="${EMIRGE_MIRGECOM_BRANCH:-master}"
-[[ -f mirgecom/setup.py ]] || git clone -b $EMIRGE_MIRGECOM_BRANCH https://github.com/illinois-ceesd/mirgecom
-
 declare -a module_names
 declare -a module_urls
 declare -a module_branches
 
 parse_requirements() {
-    local MY_MODULES=$(cat mirgecom/requirements.txt)
+    requirements_file=$1
+    if [ -z "$requirements_file" ]
+    then
+        printf "Error: No requirements file specified.\n"
+        exit 1
+    fi
+    if [ ! -f "$requirements_file" ]
+    then
+        printf "Error: Requirements file ($requirements_file) does not exist.\n"
+        exit 1
+    fi
+    local MY_MODULES=$(cat $requirements_file)
 
     for module in $MY_MODULES; do
 

--- a/parse_requirements.sh
+++ b/parse_requirements.sh
@@ -10,7 +10,7 @@ parse_requirements() {
     [[ -z "$requirements_file" ]] && echo "Error: No requirements file specified."
     [[ ! -f "$requirements_file" ]] && echo "Error: Requirements file ($requirements_file) does not exist."
     local MY_MODULES
-    MY_MODULES=$(grep -E -v '^[[:space:]]*#' $requirements_file)
+    MY_MODULES=$(grep -E -v '^[[:space:]]*#' "$requirements_file")
 
     for module in $MY_MODULES; do
 

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,11 @@
 
 set -o nounset -o errexit
 
-
+requirements_file=$1
+if [ ! -f "$requirements_file" ]
+then
+    printf "version.sh::Error: Requirements file ($requirements_file) does not exist."
+fi
 echo "*** Pip info"
 
 python3 -m pip freeze
@@ -34,7 +38,7 @@ echo "*** Emirge modules"
 
 source ./parse_requirements.sh
 
-parse_requirements
+parse_requirements $requirements_file
 
 res="Package|Branch|URL\n"
 res+="=======|======|======\n"

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,8 @@
 
 set -o nounset -o errexit
 
-requirements_file=$1
+requirements_file=${1-mirgecom/requirements.txt}
+
 if [ ! -f "$requirements_file" ]
 then
     printf "version.sh::Error: Requirements file ($requirements_file) does not exist."

--- a/version.sh
+++ b/version.sh
@@ -4,13 +4,14 @@ set -o nounset -o errexit
 
 requirements_file=${1-mirgecom/requirements.txt}
 
-if [ ! -f "$requirements_file" ]
+if [[ ! -f "$requirements_file" ]]
 then
-    printf "version.sh::Error: Requirements file ($requirements_file) does not exist."
+    echo "version.sh::Error: Requirements file ($requirements_file) does not exist."
 fi
+
 echo "*** Pip info"
 
-python3 -m pip freeze
+python -m pip freeze
 
 
 echo
@@ -39,7 +40,7 @@ echo "*** Emirge modules"
 
 source ./parse_requirements.sh
 
-parse_requirements $requirements_file
+parse_requirements "$requirements_file"
 
 res="Package|Branch|URL\n"
 res+="=======|======|======\n"


### PR DESCRIPTION
This PR adds the capability to install _mirgecom_ (and its development dependency packages) to a user-specified directory.  It modifies the existing option `--prefix` = `--conda-prefix` and adds a new `--install-prefix` option.