### PR TITLE
Options --conda-pkgs=FILE --pip-pkgs=FILE

### DIFF
--- a/install-conda-dependencies.sh
+++ b/install-conda-dependencies.sh
@@ -20,9 +20,10 @@ if [[ ! -z "$pkg_file" ]]
 then
 
     echo "  == Installing packages from file ($pkg_file)."
-    for package in $(cat $pkg_file); do
+    # shellcheck disable=SC2013
+    for package in $(cat "$pkg_file"); do
         echo "   -- Installing user-custom package ($package)."
-        conda install --yes $package
+        conda install --yes "$package"
     done
 
 else

--- a/install-conda-dependencies.sh
+++ b/install-conda-dependencies.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#
+# This script will install conda packages (in the current conda env) to satisfy 
+# mirgecom dependency requirements. It optionally accepts an argument that is
+# the path to a file which should have a list of packages to install.
+#
+# Usage: install-conda-dependencies.sh [path/to/optional/packages.txt]
+#
+ 
 set -o errexit
 pkg_file=""
 if [[ ! -z "$1" ]]

--- a/install-conda-dependencies.sh
+++ b/install-conda-dependencies.sh
@@ -1,23 +1,45 @@
 #!/bin/bash
 
 set -o errexit
+pkg_file=""
+if [[ ! -z "$1" ]]
+then
+    pkg_file="$1"
+    if [[ ! -f "$pkg_file" ]]
+    then
+        echo "install-conda-dependencies.sh::Error: Package file ($pkg_file) not found."
+        exit 1
+    fi
+fi
 
-echo "==== Installing Conda packages for $(which conda)"
+echo "==== Installing Conda packages with $(which conda)"
 
 conda info --envs
 
-if [[ $(uname) == "Darwin" ]]; then
-    conda install --yes pocl
+if [[ ! -z "$pkg_file" ]] 
+then
+
+    echo "  == Installing packages from file ($pkg_file)."
+    for package in $(cat $pkg_file); do
+        echo "   -- Installing user-custom package ($package)."
+        conda install --yes $package
+    done
+
 else
-    conda install --yes pocl-cuda
-fi
 
-conda install --yes pyvisfile pyopencl islpy
+    if [[ $(uname) == "Darwin" ]]; then
+        conda install --yes pocl
+    else
+        conda install --yes pocl-cuda
+    fi
 
-[[ $(uname -m) == "x86_64" ]] && conda install --yes clinfo
-
-# We need an MPI installation to build mpi4py.
-# Install OpenMPI if none is available.
-if ! command -v mpicc &> /dev/null ;then
-    conda install --yes openmpi openmpi-mpicc
+    conda install --yes pyvisfile pyopencl islpy
+    
+    [[ $(uname -m) == "x86_64" ]] && conda install --yes clinfo
+    
+    # We need an MPI installation to build mpi4py.
+    # Install OpenMPI if none is available.
+    if ! command -v mpicc &> /dev/null ;then
+        conda install --yes openmpi openmpi-mpicc
+    fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,8 @@ usage()
   echo "  --env-name=NAME       Name of the conda environment to install to. (default=dgfem)"
   echo "  --modules             Create modules.zip and add to Python path."
   echo "  --branch=NAME         Install specific branch of mirgecom (default=master)."
+  echo "  --conda-pkgs=FILE     Install these additional packages with conda."
+  echo "  --pip-pkgs=FILE       Install these additional packages with pip."
   echo "  --help                Print this help text."
 }
 
@@ -28,6 +30,8 @@ mcprefix=$(pwd)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 conda_prefix=$SCRIPT_DIR/miniforge3
 env_name="dgfem"
+pip_pkg_file=""
+conda_pkg_file=""
 
 # }}}
 
@@ -53,6 +57,14 @@ while [[ $# -gt 0 ]]; do
     --branch=*)
         # Install specified branch of mirgecom
         mcbranch=${arg#*=}
+        ;;
+    --conda-pkgs=*)
+        # Install these additional packages with conda
+        conda_pkg_file=${arg#*=}
+        ;;
+    --pip-pkgs=*)
+        # Install these additional packages with pip
+        pip_pkg_file=${arg#*=}
         ;;
     --modules)
         # Create modules.zip
@@ -96,7 +108,13 @@ mcsrc="$mcprefix/mirgecom"
 
 ./fetch-mirgecom.sh "$mcbranch" "$mcprefix"
 ./install-conda-dependencies.sh
+if [[ ! -z "$conda_pkg_file" ]]; then
+    ./install-conda-dependencies.sh "$conda_pkg_file"
+fi
 ./install-pip-dependencies.sh "$mcsrc/requirements.txt" "$mcprefix"
+if [[ ! -z "$pip_pkg_file" ]]; then
+    ./install-pip-dependencies.sh "$pip_pkg_file" "$mcprefix"
+fi
 ./install-src-package.sh "$mcsrc" "develop"
 
 # Install an environment activation script
@@ -121,7 +139,7 @@ echo "==================================================================="
 echo "Mirgecom is now installed in $mcsrc."
 echo "Before using this installation, one should load the appropriate"
 echo "conda environment (assuming bash shell):"
-echo " $ source $mcprefix/activate_env.sh"
+echo " $ source $mcprefix/config/activate_env.sh"
 echo "To test the installation:"
 echo " $ cd $mcsrc/test && pytest *.py"
 echo "To run the examples:"


### PR DESCRIPTION
This PR adds two options:

`--conda-pkgs=FILE` allows user to direct _emirge_ to install additional/custom packages into the conda environment.  The FILE should be a text file with a list of package names.

`--pip-pkgs=FILE` allows the user to direct _emirge_ to install additional/custom packages using pip.  The FILE should be a list of packages with the same syntax as `requirements.txt`.  Git packages will automatically be cloned in the install location.

