### PR TITLE
Run examples instead of just wave-eager.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,5 +38,5 @@ jobs:
     - name: Run examples
       run: |
         source miniforge3/bin/activate dgfem
-        ./examples/run_examples.sh ./examples
+        ./mirgecom/examples/run_examples.sh ./mirgecom/examples
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,8 @@ jobs:
       run: |
         source miniforge3/bin/activate dgfem
         ./version.sh ./mirgecom/requirements.txt
-    - name: Run wave-eager
+    - name: Run examples
       run: |
         source miniforge3/bin/activate dgfem
-        python mirgecom/examples/wave-eager.py
+        ./examples/run_example.sh ./examples
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,5 +38,5 @@ jobs:
     - name: Run examples
       run: |
         source miniforge3/bin/activate dgfem
-        ./examples/run_example.sh ./examples
+        ./examples/run_examples.sh ./examples
 


### PR DESCRIPTION
Sorry, just one more.  I only noticed this after watching CI.  Thought we had updated this to exercise all the examples instead of just wave-eager.   Note that if this gets merged, it will also try to automatically run the MPI examples - so if there are MPI examples and the CI host is not set up to run `mpiexec`, then that CI step will fail.