### PR TITLE
Revert "mpi4py workaround (#143)"

### DIFF
--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -37,8 +37,4 @@ if [[ $(mpicc --version) == "IBM XL"* ]]; then
     exit 1
 fi
 
-# Workaround for https://github.com/mpi4py/mpi4py/issues/157
-# Revisit this by Feb 2022
-export SETUPTOOLS_USE_DISTUTILS=stdlib
-
 pip install --src . -r "$requirements_file"


### PR DESCRIPTION
This reverts commit cae95cf633e834e60c111ca471e288ec238d55da.

The underlying setuptools bug has been fixed:
https://github.com/pypa/setuptools/pull/2987