### PR TITLE
Revert "limit flake8 version due to flake8-quotes incompatibility (#156)"

### DIFF
--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -26,9 +26,7 @@ python -m pip install mako
 python -m pip install pybind11
 
 # Some nice-to haves for development
-## flake8-quotes is currently incompatible with flake 6
-## (https://github.com/zheller/flake8-quotes/issues/110).
-python -m pip install pytest pudb "flake8<6" pep8-naming flake8-quotes flake8-bugbear \
+python -m pip install pytest pudb flake8 pep8-naming flake8-quotes flake8-bugbear \
                       pytest-pudb sphinx \
                       sphinx_math_dollar sphinx_copybutton furo
 

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ echo "==== Conda installation"
 
 # Make sure we get the just installed conda.
 # See https://github.com/conda/conda/issues/10133 for details.
-#shellcheck disable=SC1090
+#shellcheck disable=SC1091
 source "$MY_CONDA_DIR"/bin/activate
 
 export PATH=$MY_CONDA_DIR/bin:$PATH
@@ -168,7 +168,7 @@ conda deactivate
 # Strike 2: deactivate conda base env:
 conda deactivate
 # Strike 3: activate the desired env, which now actually works:
-#shellcheck disable=SC1090
+#shellcheck disable=SC1091
 source "$MY_CONDA_DIR"/bin/activate "$env_name"
 
 if [[ -n "$conda_pkg_file" ]]; then


### PR DESCRIPTION
This reverts commit b88a6cafecf4de59465109a5aa7b9295e57a1767 / #156.

flake8-quotes v3.3.2 is compatible with flake8 v6.