### PR TITLE
add --py-ver option to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In most cases, running `./install.sh` should be sufficient to install all packag
 - `--git-ssh`: Use SSH-based URL to clone mirgecom.
 - `--debug`: Show debugging output of this script (set -x).
 - `--skip-clone`: Skip cloning mirgecom, assume it will be manually copied to the selected installation prefix.
+- `--py-ver=VERSION`: Replace the Python version specified in the conda environment file with `VERSION` (e.g., `--py-ver=3.10`).
 - `--help`: Print this help text.
 
 ## Testing the installation

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,8 @@ opt_git_ssh=0
 # Skip cloning mirgecom
 opt_skip_clone=0
 
+opt_py_ver=
+
 while [[ $# -gt 0 ]]; do
   arg=$1
   shift
@@ -110,6 +112,10 @@ while [[ $# -gt 0 ]]; do
     --skip-clone)
         opt_skip_clone=1
         ;;
+    --py-ver=*)
+        # Install this python version instead of the version specified in the conda env file.
+        opt_py_ver=${arg#*=}
+        ;;
     --help)
         usage
         exit 0
@@ -158,6 +164,13 @@ fi
 echo "==== Create $env_name conda environment"
 
 [[ -z $conda_env_file ]] && conda_env_file="$mcsrc/conda-env.yml"
+
+if [[ -n $opt_py_ver ]]; then
+  echo "=== Overriding Python version with $opt_py_ver"
+  sed -i.bak "s,- python=3[0-9\.]*,- python=$opt_py_ver," "$conda_env_file"
+fi
+
+cat "$conda_env_file"
 
 mamba env create --name "$env_name" --force --file="$conda_env_file"
 


### PR DESCRIPTION
To support packages that don't fully handle Python 3.11 yet (e.g., vmprof).