### PR TITLE
Readme: remove outdated manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In most cases, running `./install.sh` should be sufficient to install all packag
 - `--git-ssh`: Use SSH-based URL to clone mirgecom.
 - `--debug`: Show debugging output of this script (set -x).
 - `--skip-clone`: Skip cloning mirgecom, assume it will be manually copied to the selected installation prefix.
+- `--py-ver=VERSION`: Replace the Python version specified in the conda environment file with `VERSION` (e.g., `--py-ver=3.10`).
 - `--help`: Print this help text.
 
 ## Testing the installation

--- a/README.md
+++ b/README.md
@@ -29,81 +29,10 @@ In most cases, running `./install.sh` should be sufficient to install all packag
 - `--py-ver=VERSION`: Replace the Python version specified in the conda environment file with `VERSION` (e.g., `--py-ver=3.10`).
 - `--help`: Print this help text.
 
-## Testing the installation
+# Testing the installation
 
 Testing can be done by:
 
 ```bash
 $ mirgecom/examples/run_examples.sh mirgecom/examples/
-```
-
-## Running on systems with lots of nodes (>256)
-On large systems, the file system can become a bottleneck for loading Python
-packages. On these systems, it is recommended to create a zip file with the
-modules to speed up the startup process. This can be done by specifying the
-`--modules` parameter to `install.sh`, or by running `makezip.sh` after
-installation.
-
-See https://github.com/illinois-ceesd/planning/issues/26 for more details.
-
-
-# Manual installation
-
-Please use the instructions above instead.
-
-## Running wavelet0
-
-
-### Prerequesites
-
-#### Install POCL
-
-##### Installation with conda-miniforge
-
-```bash
-$ wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-# For Power8/9:
-# $ wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-ppc64le.sh
-# For MacOS:
-# $ wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh
-
-# Install Miniforge/conda:
-$ bash ./Miniforge3-Linux-x86_64.sh
-
-# Optional: create conda environment
-$ export MY_CONDA=/path/to/installed/conda # Default installation path: $HOME/miniforge3
-$ $MY_CONDA/bin/conda create -n ceesd
-$ . $MY_CONDA/bin/activate ceesd
-
-# Install required conda packages:
-$ conda install pip pocl numpy pyopencl islpy flake8 mypy pudb
-
-# Install optional conda packages:
-$ conda install clinfo
-
-# In a new session, you may reactivate this environment using:
-. $MY_CONDA/bin/activate ceesd
-```
-
-##### Installation with Spack
-
-```bash
-$ git clone git@github.com:spack/spack
-$ source spack/share/spack/setup-env.sh
-# Maybe edit your Spack config
-# $ spack config edit packages
-$ spack install pocl
-```
-
-#### Install Python packages
-
-```bash
-$ pip install pyvisfile
-$ for m in pytools pymbolic dagrt leap loopy meshmode grudge mirgecom; do cd $m && pip install -e . && cd ..; done
-```
-
-### Run wavelet0
-
-```bash
-$ cd mirgecom/examples; python wave-eager.py
 ```

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,8 @@ opt_git_ssh=0
 # Skip cloning mirgecom
 opt_skip_clone=0
 
+opt_py_ver=
+
 while [[ $# -gt 0 ]]; do
   arg=$1
   shift
@@ -110,6 +112,10 @@ while [[ $# -gt 0 ]]; do
     --skip-clone)
         opt_skip_clone=1
         ;;
+    --py-ver=*)
+        # Install this python version instead of the version specified in the conda env file.
+        opt_py_ver=${arg#*=}
+        ;;
     --help)
         usage
         exit 0
@@ -158,6 +164,13 @@ fi
 echo "==== Create $env_name conda environment"
 
 [[ -z $conda_env_file ]] && conda_env_file="$mcsrc/conda-env.yml"
+
+if [[ -n $opt_py_ver ]]; then
+  echo "=== Overriding Python version with $opt_py_ver"
+  sed -i.bak "s,- python=3[0-9\.]*,- python=$opt_py_ver," "$conda_env_file"
+fi
+
+cat "$conda_env_file"
 
 mamba env create --name "$env_name" --force --file="$conda_env_file"
 


### PR DESCRIPTION
These are unlikely to be working anymore, since we put a lot of effort in recording package dependencies in mirgecom requirements/conda-env itself.

The 'Running on lots of nodes' section is also completely outdated, I think it's better to keep that documentation in mirgecom itself.