### PR TITLE
export MPI4PY_BUILD_CONFIGURE

### DIFF
--- a/install-pip-dependencies.sh
+++ b/install-pip-dependencies.sh
@@ -37,4 +37,7 @@ if [[ $(mpicc --version) == "IBM XL"* ]]; then
     exit 1
 fi
 
+
+# Install the packages from the requirements file
+export MPI4PY_BUILD_CONFIGURE=1
 pip install --src . -r "$requirements_file"


### PR DESCRIPTION
Indicates to mpi4py to configure itself before building.